### PR TITLE
Fixed scheduler

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ discord==0.16.12
 feedparser==5.2.1
 mysql-connector==2.2.9
 redis
+python-dateutil

--- a/suitsBot_d.py
+++ b/suitsBot_d.py
@@ -77,7 +77,8 @@ async def post_apod(curr_time):
             embed.set_footer(icon_url=embed_icon,
                              text="NASA Astronomy Photo of the Day https://apod.nasa.gov/apod/astropix.html")
             embed.colour = EMBED_COLORS["nasa"]
-            await bot.send_message(bot.APOD_CHANNELS, embed=embed)
+            for apod_channel in bot.APOD_CHANNELS:
+                await bot.send_message(apod_channel, embed=embed)
     except Exception as e:
         await utils.report(bot, str(e), source="Daily APOD command")
 


### PR DESCRIPTION
Fixed scheduler by having it assume it had run at the appropriate time on restarts.  Then compares last run datetime to now plus the interval.

New dependency of python-dateutil.  This is a very popular library.  In this case, we need to use relativedelta to properly deal with leap years instead of the inferior built-in timedelta.