### PR TITLE
Bot couldn't count

### DIFF
--- a/embedGenerator.py
+++ b/embedGenerator.py
@@ -189,10 +189,7 @@ async def discord_message(ids: str, _: Message) -> Optional[Embed]:
 
     # Collapse Reactions to a single list
     if linked_message.reactions:
-        react_dict = dict()
-        for reaction in linked_message.reactions:
-            react_dict[reaction.emoji] = 1 if reaction.emoji not in react_dict else react_dict[reaction.emoji] + 1
-        react_str = " ‍ ‍ ".join([f"{emoji} **{count}**" for emoji, count in react_dict.items()])
+        react_str = " ‍ ‍ ".join([f"{reaction.emoji} **{reaction.count}**" for reaction in linked_message.reactions])
         embed.add_field(name="Reactions", value=utils.trim_to_len(react_str, 1024))
 
     """ Add timestamp to footer """


### PR DESCRIPTION
embedGenerator.py
- Reactions to Discord Messages are now accurately counted instead of all just saying "1"